### PR TITLE
Fix stray char in ComfyUI utils

### DIFF
--- a/src/utils/comfyui.py
+++ b/src/utils/comfyui.py
@@ -182,7 +182,6 @@ def get_history(
     """
     Recupera o histórico de execuções de um dado prompt_id via GET em /history/{prompt_id}.
     Retorna o JSON completo da resposta.
-D
     :param prompt_id: Identificador do prompt gerado anteriormente.
     :param server_address: Endereço base do servidor ComfyUI.
     :param aws_alb_cookie: Cookie AWSALB para autenticação (opcional).


### PR DESCRIPTION
## Summary
- remove dangling `D` line from `get_history` docstring

## Testing
- `python -m py_compile src/utils/comfyui.py`
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_6861e5a60848832db3838924b3c068ad